### PR TITLE
Batch of fixes for Sashimi.AzureScripting to target Server 2020.5

### DIFF
--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,8 +15,8 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="15.1.5" />
-        <PackageReference Include="Calamari.Scripting" Version="8.3.4" />
+        <PackageReference Include="Calamari.Common" Version="15.1.6" />
+        <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="10.0.6" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.3.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
-        <PackageReference Include="Sashimi.Azure.Common" Version="8.3.4" />
-        <PackageReference Include="Sashimi.Azure.Accounts" Version="8.3.4" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="8.3.4" />
+        <PackageReference Include="Sashimi.Azure.Common" Version="8.5.4" />
+        <PackageReference Include="Sashimi.Azure.Accounts" Version="8.5.4" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.5" />
+</packages>


### PR DESCRIPTION
Fixes both:
- https://github.com/OctopusDeploy/Issues/issues/6683
- https://github.com/OctopusDeploy/Issues/issues/6778

For netfull we need to explicitly enable long file paths in the config file.
Update references to Calamari + Sashimi to match what the Server is referencing
Had to lock the cake version because v1 does not work!

Cake error with v1:
![image](https://user-images.githubusercontent.com/122651/109563561-ab23ea80-7b2b-11eb-9406-c83ad9dc4a59.png)
