### PR TITLE
Use '=' in argument because of Azure CLI bug

### DIFF
--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -21,11 +21,13 @@
 
 $ErrorActionPreference = "Stop"
 
-if ($PSVersionTable.PSVersion.Major -lt 5) {
+if ($PSVersionTable.PSVersion.Major -lt 5)
+{
     throw "These Azure commands are only supported in PowerShell versions 5 and above. This server is currently running PowerShell version $($PSVersionTable.PSVersion.ToString())."
 }
 
-function EnsureDirectoryExists([string] $path) {
+function EnsureDirectoryExists([string] $path)
+{
     New-Item -ItemType Directory -Force -Path $path *>$null
 }
 
@@ -48,19 +50,17 @@ function Execute-WithRetry([ScriptBlock] $command) {
             & $command
 
             $operationIncomplete = $false
-        }
-        catch [System.Exception] {
+        } catch [System.Exception] {
             if ($attemptCount -lt ($maxFailures)) {
                 Write-Host ("Attempt $attemptCount of $maxFailures failed: " + $_.Exception.Message)
-            }
-            else {
+            } else {
                 throw
             }
         }
     }
 }
 
-Execute-WithRetry {
+Execute-WithRetry{
     pushd $env:OctopusCalamariWorkingDirectory
     try {
         If ([System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
@@ -68,51 +68,51 @@ Execute-WithRetry {
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
             
-            # if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
-            # {
-            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-            #     Disable-AzureRMContextAutosave -Scope Process
+            if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            {
+                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+                Disable-AzureRMContextAutosave -Scope Process
 
-            #     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-            #     if (!$AzureEnvironment)
-            #     {
-            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-            #         exit -2
-            #     }
+                $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+                if (!$AzureEnvironment)
+                {
+                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+                    exit -2
+                }
 
-            #     Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+                Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
 
-            #     # Force any output generated to be verbose in Octopus logs.
-            #     Write-Host "##octopus[stdout-verbose]"
-            #     Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-            #     Write-Host "##octopus[stdout-default]"
-            # }
-            # elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
-            # {
-            #     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-            #     {
-            #         # Turn on AzureRm aliasing
-            #         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-            #         Enable-AzureRmAlias -Scope Process
-            #     }
+                # Force any output generated to be verbose in Octopus logs.
+                Write-Host "##octopus[stdout-verbose]"
+                Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+                Write-Host "##octopus[stdout-default]"
+            }
+            elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
+            {
+                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+                {
+                    # Turn on AzureRm aliasing
+                    # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+                    Enable-AzureRmAlias -Scope Process
+                }
 
-            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-            #     Disable-AzContextAutosave -Scope Process
+                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+                Disable-AzContextAutosave -Scope Process
 
-            #     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-            #     if (!$AzureEnvironment)
-            #     {
-            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-            #         exit -2
-            #     }
+                $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+                if (!$AzureEnvironment)
+                {
+                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+                    exit -2
+                }
 
-            #     Write-Verbose "Az Modules: Authenticating with Service Principal"
+                Write-Verbose "Az Modules: Authenticating with Service Principal"
 
-            #     # Force any output generated to be verbose in Octopus logs.
-            #     Write-Host "##octopus[stdout-verbose]"
-            #     Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-            #     Write-Host "##octopus[stdout-default]"
-            # }
+                # Force any output generated to be verbose in Octopus logs.
+                Write-Host "##octopus[stdout-verbose]"
+                Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+                Write-Host "##octopus[stdout-default]"
+            }
             
             If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
                 try {
@@ -127,11 +127,11 @@ Execute-WithRetry {
                     # The azure extensions directory is getting overridden above when we set the azure config dir (undocumented behavior). 
                     # Set the azure extensions directory to the value of $OctopusAzureExtensionsDirectory if specified, 
                     # otherwise, back to the default value of $HOME\.azure\cliextension.
-                    if ($OctopusAzureExtensionsDirectory) { 
+                    if($OctopusAzureExtensionsDirectory) 
+                    { 
                         Write-Host "Setting Azure CLI extensions directory to $OctopusAzureExtensionsDirectory" 
                         $env:AZURE_EXTENSION_DIR = $OctopusAzureExtensionsDirectory 
-                    }
-                    else { 
+                    } else { 
                         $env:AZURE_EXTENSION_DIR = "$($HOME)\.azure\cliextensions" 
                     } 
 
@@ -157,22 +157,21 @@ Execute-WithRetry {
 
                     Write-Host "##octopus[stdout-default]"
                     Write-Verbose "Successfully authenticated with the Azure CLI"
-                }
-                catch {
+                } catch  {
                     # failed to authenticate with Azure CLI
                     Write-Verbose "Failed to authenticate with Azure CLI"
                     Write-Verbose $_.Exception.Message
                 }
             }
-        }
-        Else {
+        } Else {
             # Authenticate via Management Certificate
             Write-Verbose "Loading the management certificate"
             Add-Type -AssemblyName "System"
             $certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
-            $AzureEnvironment = Get-AzureEnvironment | Where-Object { $_.Name -eq $OctopusAzureEnvironment }
+            $AzureEnvironment = Get-AzureEnvironment | Where-Object {$_.Name -eq $OctopusAzureEnvironment}
 
-            if (!$AzureEnvironment) {
+            if (!$AzureEnvironment)
+            {
                 Write-Error "No Azure environment could be matched given name $OctopusAzureEnvironment"
                 exit -2
             }
@@ -191,16 +190,14 @@ Write-Verbose "Invoking target script $OctopusAzureTargetScript with $OctopusAzu
 
 try {
     Invoke-Expression ". `"$OctopusAzureTargetScript`" $OctopusAzureTargetScriptParameters"
-}
-catch {
+} catch {
     # Warn if FIPS 140 compliance required when using Service Management SDK
     if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
         Write-Warning "The Azure Service Management SDK is not FIPS 140 compliant. http://g.octopushq.com/FIPS"
     }
 
     throw
-}
-finally {
+} finally {
     If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
         try {
             # Save the last exit code so az logout doesn't clobber it
@@ -208,8 +205,7 @@ finally {
             $previousErrorAction = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
             az logout 2>$null 3>$null
-        }
-        finally {
+        } finally {
             # restore the previous last exit code
             $LastExitCode = $previousLastExitCode
             $ErrorActionPreference = $previousErrorAction

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,51 +68,51 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
             
-            if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
-            {
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzureRMContextAutosave -Scope Process
+            # if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            # {
+            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+            #     Disable-AzureRMContextAutosave -Scope Process
 
-                $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
-                }
+            #     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+            #     if (!$AzureEnvironment)
+            #     {
+            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+            #         exit -2
+            #     }
 
-                Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+            #     Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
 
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
-            }
-            elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
-            {
-                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-                {
-                    # Turn on AzureRm aliasing
-                    # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-                    Enable-AzureRmAlias -Scope Process
-                }
+            #     # Force any output generated to be verbose in Octopus logs.
+            #     Write-Host "##octopus[stdout-verbose]"
+            #     Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+            #     Write-Host "##octopus[stdout-default]"
+            # }
+            # elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
+            # {
+            #     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+            #     {
+            #         # Turn on AzureRm aliasing
+            #         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+            #         Enable-AzureRmAlias -Scope Process
+            #     }
 
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzContextAutosave -Scope Process
+            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+            #     Disable-AzContextAutosave -Scope Process
 
-                $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
-                }
+            #     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+            #     if (!$AzureEnvironment)
+            #     {
+            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+            #         exit -2
+            #     }
 
-                Write-Verbose "Az Modules: Authenticating with Service Principal"
+            #     Write-Verbose "Az Modules: Authenticating with Service Principal"
 
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
-            }
+            #     # Force any output generated to be verbose in Octopus logs.
+            #     Write-Host "##octopus[stdout-verbose]"
+            #     Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+            #     Write-Host "##octopus[stdout-default]"
+            # }
             
             If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
                 try {

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,51 +68,51 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
             
-            # if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
-            # {
-            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-            #     Disable-AzureRMContextAutosave -Scope Process
+            if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            {
+                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+                Disable-AzureRMContextAutosave -Scope Process
 
-            #     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-            #     if (!$AzureEnvironment)
-            #     {
-            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-            #         exit -2
-            #     }
+                $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+                if (!$AzureEnvironment)
+                {
+                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+                    exit -2
+                }
 
-            #     Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+                Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
 
-            #     # Force any output generated to be verbose in Octopus logs.
-            #     Write-Host "##octopus[stdout-verbose]"
-            #     Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-            #     Write-Host "##octopus[stdout-default]"
-            # }
-            # elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
-            # {
-            #     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-            #     {
-            #         # Turn on AzureRm aliasing
-            #         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-            #         Enable-AzureRmAlias -Scope Process
-            #     }
+                # Force any output generated to be verbose in Octopus logs.
+                Write-Host "##octopus[stdout-verbose]"
+                Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+                Write-Host "##octopus[stdout-default]"
+            }
+            elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
+            {
+                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+                {
+                    # Turn on AzureRm aliasing
+                    # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+                    Enable-AzureRmAlias -Scope Process
+                }
 
-            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-            #     Disable-AzContextAutosave -Scope Process
+                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+                Disable-AzContextAutosave -Scope Process
 
-            #     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-            #     if (!$AzureEnvironment)
-            #     {
-            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-            #         exit -2
-            #     }
+                $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+                if (!$AzureEnvironment)
+                {
+                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+                    exit -2
+                }
 
-            #     Write-Verbose "Az Modules: Authenticating with Service Principal"
+                Write-Verbose "Az Modules: Authenticating with Service Principal"
 
-            #     # Force any output generated to be verbose in Octopus logs.
-            #     Write-Host "##octopus[stdout-verbose]"
-            #     Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-            #     Write-Host "##octopus[stdout-default]"
-            # }
+                # Force any output generated to be verbose in Octopus logs.
+                Write-Host "##octopus[stdout-verbose]"
+                Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+                Write-Host "##octopus[stdout-default]"
+            }
             
             If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
                 try {

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -21,13 +21,11 @@
 
 $ErrorActionPreference = "Stop"
 
-if ($PSVersionTable.PSVersion.Major -lt 5)
-{
+if ($PSVersionTable.PSVersion.Major -lt 5) {
     throw "These Azure commands are only supported in PowerShell versions 5 and above. This server is currently running PowerShell version $($PSVersionTable.PSVersion.ToString())."
 }
 
-function EnsureDirectoryExists([string] $path)
-{
+function EnsureDirectoryExists([string] $path) {
     New-Item -ItemType Directory -Force -Path $path *>$null
 }
 
@@ -50,17 +48,19 @@ function Execute-WithRetry([ScriptBlock] $command) {
             & $command
 
             $operationIncomplete = $false
-        } catch [System.Exception] {
+        }
+        catch [System.Exception] {
             if ($attemptCount -lt ($maxFailures)) {
                 Write-Host ("Attempt $attemptCount of $maxFailures failed: " + $_.Exception.Message)
-            } else {
+            }
+            else {
                 throw
             }
         }
     }
 }
 
-Execute-WithRetry{
+Execute-WithRetry {
     pushd $env:OctopusCalamariWorkingDirectory
     try {
         If ([System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
@@ -68,51 +68,51 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
             
-            if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
-            {
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzureRMContextAutosave -Scope Process
+            # if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            # {
+            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+            #     Disable-AzureRMContextAutosave -Scope Process
 
-                $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
-                }
+            #     $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+            #     if (!$AzureEnvironment)
+            #     {
+            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+            #         exit -2
+            #     }
 
-                Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+            #     Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
 
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
-            }
-            elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
-            {
-                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-                {
-                    # Turn on AzureRm aliasing
-                    # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-                    Enable-AzureRmAlias -Scope Process
-                }
+            #     # Force any output generated to be verbose in Octopus logs.
+            #     Write-Host "##octopus[stdout-verbose]"
+            #     Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+            #     Write-Host "##octopus[stdout-default]"
+            # }
+            # elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
+            # {
+            #     if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+            #     {
+            #         # Turn on AzureRm aliasing
+            #         # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+            #         Enable-AzureRmAlias -Scope Process
+            #     }
 
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzContextAutosave -Scope Process
+            #     # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+            #     Disable-AzContextAutosave -Scope Process
 
-                $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
-                }
+            #     $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+            #     if (!$AzureEnvironment)
+            #     {
+            #         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+            #         exit -2
+            #     }
 
-                Write-Verbose "Az Modules: Authenticating with Service Principal"
+            #     Write-Verbose "Az Modules: Authenticating with Service Principal"
 
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
-            }
+            #     # Force any output generated to be verbose in Octopus logs.
+            #     Write-Host "##octopus[stdout-verbose]"
+            #     Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+            #     Write-Host "##octopus[stdout-default]"
+            # }
             
             If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
                 try {
@@ -127,11 +127,11 @@ Execute-WithRetry{
                     # The azure extensions directory is getting overridden above when we set the azure config dir (undocumented behavior). 
                     # Set the azure extensions directory to the value of $OctopusAzureExtensionsDirectory if specified, 
                     # otherwise, back to the default value of $HOME\.azure\cliextension.
-                    if($OctopusAzureExtensionsDirectory) 
-                    { 
+                    if ($OctopusAzureExtensionsDirectory) { 
                         Write-Host "Setting Azure CLI extensions directory to $OctopusAzureExtensionsDirectory" 
                         $env:AZURE_EXTENSION_DIR = $OctopusAzureExtensionsDirectory 
-                    } else { 
+                    }
+                    else { 
                         $env:AZURE_EXTENSION_DIR = "$($HOME)\.azure\cliextensions" 
                     } 
 
@@ -157,21 +157,22 @@ Execute-WithRetry{
 
                     Write-Host "##octopus[stdout-default]"
                     Write-Verbose "Successfully authenticated with the Azure CLI"
-                } catch  {
+                }
+                catch {
                     # failed to authenticate with Azure CLI
                     Write-Verbose "Failed to authenticate with Azure CLI"
                     Write-Verbose $_.Exception.Message
                 }
             }
-        } Else {
+        }
+        Else {
             # Authenticate via Management Certificate
             Write-Verbose "Loading the management certificate"
             Add-Type -AssemblyName "System"
             $certificate = new-object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @($OctopusAzureCertificateFileName, $OctopusAzureCertificatePassword, ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] "PersistKeySet", "Exportable"))
-            $AzureEnvironment = Get-AzureEnvironment | Where-Object {$_.Name -eq $OctopusAzureEnvironment}
+            $AzureEnvironment = Get-AzureEnvironment | Where-Object { $_.Name -eq $OctopusAzureEnvironment }
 
-            if (!$AzureEnvironment)
-            {
+            if (!$AzureEnvironment) {
                 Write-Error "No Azure environment could be matched given name $OctopusAzureEnvironment"
                 exit -2
             }
@@ -190,14 +191,16 @@ Write-Verbose "Invoking target script $OctopusAzureTargetScript with $OctopusAzu
 
 try {
     Invoke-Expression ". `"$OctopusAzureTargetScript`" $OctopusAzureTargetScriptParameters"
-} catch {
+}
+catch {
     # Warn if FIPS 140 compliance required when using Service Management SDK
     if ([System.Security.Cryptography.CryptoConfig]::AllowOnlyFipsAlgorithms -and ![System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
         Write-Warning "The Azure Service Management SDK is not FIPS 140 compliant. http://g.octopushq.com/FIPS"
     }
 
     throw
-} finally {
+}
+finally {
     If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {
         try {
             # Save the last exit code so az logout doesn't clobber it
@@ -205,7 +208,8 @@ try {
             $previousErrorAction = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
             az logout 2>$null 3>$null
-        } finally {
+        }
+        finally {
             # restore the previous last exit code
             $LastExitCode = $previousLastExitCode
             $ErrorActionPreference = $previousErrorAction

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -144,10 +144,10 @@ Execute-WithRetry{
                     Write-Host "Azure CLI: Authenticating with Service Principal"
 
                     $loginArgs = @();
-                    $loginArgs += @("-u", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADClientId))));
                     # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
-                    $loginArgs += @("--password", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADPassword))));
-                    $loginArgs += @("--tenant", (ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADTenantId))));
+                    $loginArgs += @("--username=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADClientId)))");
+                    $loginArgs += @("--password=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADPassword)))");
+                    $loginArgs += @("--tenant=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADTenantId)))");
                     az login --service-principal $loginArgs
 
                     Write-Host "Azure CLI: Setting active subscription to $OctopusAzureSubscriptionId"

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -148,6 +148,8 @@ Execute-WithRetry{
                     $loginArgs += @("--username=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADClientId)))");
                     $loginArgs += @("--password=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADPassword)))");
                     $loginArgs += @("--tenant=$(ConvertTo-QuotedString(ConvertTo-ConsoleEscapedArgument($OctopusAzureADTenantId)))");
+                    
+                    Write-Host "az login --service-principal $loginArgs"
                     az login --service-principal $loginArgs
 
                     Write-Host "Azure CLI: Setting active subscription to $OctopusAzureSubscriptionId"

--- a/source/Calamari/Scripts/AzureContext.sh
+++ b/source/Calamari/Scripts/AzureContext.sh
@@ -45,7 +45,8 @@ function setup_context {
         loginArgs+=("--password=$Octopus_Azure_ADPassword")
         loginArgs+=("--tenant=$Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}
-        az login --service-principal ${loginArgs[@]}
+        # Note: Need to double quote the loginArgs here to ensure that spaces aren't treated as separate arguments
+        az login --service-principal "${loginArgs[@]}"
 
         echo "Azure CLI: Setting active subscription to $Octopus_Azure_SubscriptionId"
         az account set --subscription $Octopus_Azure_SubscriptionId

--- a/source/Calamari/Scripts/AzureContext.sh
+++ b/source/Calamari/Scripts/AzureContext.sh
@@ -41,7 +41,7 @@ function setup_context {
         echo "Azure CLI: Authenticating with Service Principal"
         loginArgs=()
         # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
-        loginArgs+=("--username=$Octopus_Azure_ADClientId")        
+        loginArgs+=("--username=$Octopus_Azure_ADClientId")
         loginArgs+=("--password=$Octopus_Azure_ADPassword")
         loginArgs+=("--tenant=$Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}

--- a/source/Calamari/Scripts/AzureContext.sh
+++ b/source/Calamari/Scripts/AzureContext.sh
@@ -46,6 +46,8 @@ function setup_context {
         loginArgs+=("--tenant=$Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}
         # Note: Need to double quote the loginArgs here to ensure that spaces aren't treated as separate arguments
+        #       It also seems like putting double quotes around each individual argument makes az cli include the "
+        #       character as part of the input causing issues...
         az login --service-principal "${loginArgs[@]}"
 
         echo "Azure CLI: Setting active subscription to $Octopus_Azure_SubscriptionId"

--- a/source/Calamari/Scripts/AzureContext.sh
+++ b/source/Calamari/Scripts/AzureContext.sh
@@ -40,10 +40,10 @@ function setup_context {
 
         echo "Azure CLI: Authenticating with Service Principal"
         loginArgs=()
-        loginArgs+=("-u $Octopus_Azure_ADClientId")
         # Use the full argument because of https://github.com/Azure/azure-cli/issues/12105
-        loginArgs+=("--password $Octopus_Azure_ADPassword")
-        loginArgs+=("--tenant $Octopus_Azure_ADTenantId")
+        loginArgs+=("--username=$Octopus_Azure_ADClientId")        
+        loginArgs+=("--password=$Octopus_Azure_ADPassword")
+        loginArgs+=("--tenant=$Octopus_Azure_ADTenantId")
         echo az login --service-principal ${loginArgs[@]}
         az login --service-principal ${loginArgs[@]}
 


### PR DESCRIPTION
There is an issue with the option parsing in the Azure CLI (Azure/azure-cli#12105) that causes arguments starting with a '-' to be parsed incorrectly, this is fixed by using the full argument with a '=' e.g. --password=mypassword.

Also added verbose logging of "az login ..." to powershell to match bash.

Note: The powershell script currently escapes double quotes, I tested this in bash and we don't appear to need to do this, I imagine it's probably because we aren't quoting the arguments at all (and don't appear to need to).