### PR TITLE
Update Sashimi version

### DIFF
--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="13.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="11.0.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
-        <PackageReference Include="Sashimi.Azure.Common" Version="11.0.0" />
-        <PackageReference Include="Sashimi.Azure.Accounts" Version="11.0.0" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="11.0.0" />
+        <PackageReference Include="Sashimi.Azure.Common" Version="13.0.0" />
+        <PackageReference Include="Sashimi.Azure.Accounts" Version="13.0.0" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="13.0.0" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />


### PR DESCRIPTION
Updated Sashimi version to 13.0.0 to apply the refactoring changes of `AccountDetails` and `IVerifyAccount`

Slack thread: https://octopusdeploy.slack.com/archives/C01GYCD6VUH/p1621214903474900
Sashimi PR: https://github.com/OctopusDeploy/Sashimi/pull/116