### PR TITLE
Fixes issues with AzureRM on powershell core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -80,20 +80,20 @@ Task("Build")
     });
 });
 
-// Task("Test")
-//     .IsDependentOn("Build")
-//     .WithCriteria(BuildSystem.IsLocalBuild)
-//     .Does(() => {
-// 		var projects = GetFiles("./source/**/*Tests.csproj");
+Task("Test")
+    .IsDependentOn("Build")
+    .WithCriteria(BuildSystem.IsLocalBuild)
+    .Does(() => {
+		var projects = GetFiles("./source/**/*Tests.csproj");
 
-//         Parallel.ForEach(projects, project => {
-//             DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
-// 			{
-// 				Configuration = configuration,
-// 				NoBuild = true
-// 			});
-//         });
-//     });
+        Parallel.ForEach(projects, project => {
+            DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
+			{
+				Configuration = configuration,
+				NoBuild = true
+			});
+        });
+    });
 
 Task("PublishCalamariProjects")
    .IsDependentOn("Build")
@@ -175,7 +175,7 @@ Task("PackSashimi")
 });
 
 Task("CopyToLocalPackages")
-    // .IsDependentOn("Test")
+    .IsDependentOn("Test")
     .IsDependentOn("PackSashimi")
     .WithCriteria(BuildSystem.IsLocalBuild)
     .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -80,20 +80,20 @@ Task("Build")
     });
 });
 
-Task("Test")
-    .IsDependentOn("Build")
-    .WithCriteria(BuildSystem.IsLocalBuild)
-    .Does(() => {
-		var projects = GetFiles("./source/**/*Tests.csproj");
+// Task("Test")
+//     .IsDependentOn("Build")
+//     .WithCriteria(BuildSystem.IsLocalBuild)
+//     .Does(() => {
+// 		var projects = GetFiles("./source/**/*Tests.csproj");
 
-        Parallel.ForEach(projects, project => {
-            DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
-			{
-				Configuration = configuration,
-				NoBuild = true
-			});
-        });
-    });
+//         Parallel.ForEach(projects, project => {
+//             DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
+// 			{
+// 				Configuration = configuration,
+// 				NoBuild = true
+// 			});
+//         });
+//     });
 
 Task("PublishCalamariProjects")
    .IsDependentOn("Build")
@@ -175,7 +175,7 @@ Task("PackSashimi")
 });
 
 Task("CopyToLocalPackages")
-    .IsDependentOn("Test")
+    // .IsDependentOn("Test")
     .IsDependentOn("PackSashimi")
     .WithCriteria(BuildSystem.IsLocalBuild)
     .Does(() =>

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,17 +68,13 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
-            Get-Alias
-
-            #$useAzureRmModule = 
-            $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5
-
-            # if ($runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
-            # {
-            #     # AzureRM is not supported on powershell core, skip over this authentication method and warn of this
-            #     Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
-            #     $useAzureRmModule = $false
-            # }            
+            $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5         
+            
+            if ($runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
+            {
+                # AzureRM is not supported on powershell core, warn of this
+                Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
+            }
             
             if (!$runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
             {
@@ -101,7 +97,7 @@ Execute-WithRetry{
             }
             elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
             {
-                if (!$runningInPowershellCore -and -Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
                 {
                     Write-Verbose "Enabling AzureRM aliasing"
 

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,7 +68,10 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
             
-            if (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5            
+            
+            # AzureRM is not supported on powershell core, skip over this authentication method
+            if ((Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue) -And ($runningInPowershellCore -eq $false))
             {
                 # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
                 Disable-AzureRMContextAutosave -Scope Process

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,7 +68,10 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
-            $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5         
+            $azureRmPresent = (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue)
+            $azPresent = (Get-InstalledModule Az -ErrorAction SilentlyContinue)
+            $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5
+            Write-Host "runningInPowershellCore: $runningInPowershellCore, azureRmPresent: $azureRmPresent, azPresent: $azPresent"
             
             if ($runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
             {

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -87,7 +87,7 @@ function Initialize-AzureRmContext {
     if (!$AzureEnvironment)
     {
         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-        exit -2
+        exit 2
     }
 
     Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
@@ -122,7 +122,7 @@ function Initialize-AzContext {
     if (!$AzureEnvironment)
     {
         Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-        exit -2
+        exit 2
     }
 
     Write-Verbose "Az Modules: Authenticating with Service Principal"
@@ -224,7 +224,7 @@ Execute-WithRetry{
             if (!$AzureEnvironment)
             {
                 Write-Error "No Azure environment could be matched given name $OctopusAzureEnvironment"
-                exit -2
+                exit 2
             }
 
             $azureProfile = New-AzureProfile -SubscriptionId $OctopusAzureSubscriptionId -StorageAccount $OctopusAzureStorageAccountName -Certificate $certificate -Environment $AzureEnvironment

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -72,78 +72,97 @@ function Get-RunningInPowershellCore {
     return $PSVersionTable.PSVersion.Major -gt 5
 }
 
+function Initialize-AzureRmContext {
+    
+    # Authenticate via Service Principal
+    $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
+    $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
+
+    # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+    Write-Host "##octopus[stdout-verbose]"
+    Disable-AzureRMContextAutosave -Scope Process
+    Write-Host "##octopus[stdout-default]"
+
+    $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
+    if (!$AzureEnvironment)
+    {
+        Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+        exit -2
+    }
+
+    Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
+
+    # Force any output generated to be verbose in Octopus logs.
+    Write-Host "##octopus[stdout-verbose]"
+    Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+    Write-Host "##octopus[stdout-default]"
+}
+
+function Initialize-AzContext {
+    
+    # Authenticate via Service Principal
+    $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
+    $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
+
+    if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+    {
+        Write-Verbose "Enabling AzureRM aliasing"
+
+        # Turn on AzureRm aliasing
+        # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
+        Enable-AzureRmAlias -Scope Process
+    }
+
+    # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
+    Write-Host "##octopus[stdout-verbose]"
+    Disable-AzContextAutosave -Scope Process
+    Write-Host "##octopus[stdout-default]"
+
+    $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
+    if (!$AzureEnvironment)
+    {
+        Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
+        exit -2
+    }
+
+    Write-Verbose "Az Modules: Authenticating with Service Principal"
+
+    # Force any output generated to be verbose in Octopus logs.
+    Write-Host "##octopus[stdout-verbose]"
+    Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
+    Write-Host "##octopus[stdout-default]"
+}
+
 Execute-WithRetry{
     pushd $env:OctopusCalamariWorkingDirectory
     try {
         If ([System.Convert]::ToBoolean($OctopusUseServicePrincipal)) {
-            # Authenticate via Service Principal
-            $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
-            $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
-            $runningInPowershellCore = Get-RunningInPowershellCore
-            $azModuleInstalled = Get-AzModuleInstalled
-            $azureRmModuleInstalled = Get-AzureRmModuleInstalled
-
-            Write-Verbose "Azure Powershell environment - Powershell Core: $runningInPowershellCore, Az Module: $azModuleInstalled, AzureRM Module: $azureRmModuleInstalled"
-            
-            if ($runningInPowershellCore -and $azureRmModuleInstalled)
-            {
-                # AzureRM is not supported on powershell core
-                Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
-            }
-
-            if ($azureRmModuleInstalled -and $azModuleInstalled) 
-            {
-                # AzureRM and Az modules being installed at the same time is not supported by Microsoft
-                Write-Warning "Installing both AzureRM and Az modules at the same time is not supported and may cause unexpected errors: https://g.octopushq.com/AzureTools"
-            }
-            
-            if (!$runningInPowershellCore -and $azureRmModuleInstalled)
-            {
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzureRMContextAutosave -Scope Process
-
-                $AzureEnvironment = Get-AzureRmEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
+            # Depending on which version of Powershell we are running under will change which module context we want to initialize.            
+            #   Powershell Core: Check Az then AzureRM (provide a warning and do nothing if AzureRM is installed)
+            #   Windows Powershell: Check AzureRM then Az
+            #
+            # If a module is installed (e.g. AzureRM) then testing for it causes the module to be loaded along with its various assemblies
+            # and dependencies. If we then test for the other module (e.g. Az) then it also loads it's module and assemblies which then
+            # creates havoc when you try and call any context methods such as Disable-AzContextAutosave due to version differences etc. 
+            # For this reason we'll only test the module we prefer and then if it exists initialize it and not the other one.
+            if (Get-RunningInPowershellCore) {
+                if (Get-AzModuleInstalled) {
+                    Initialize-AzContext
                 }
-
-                Write-Verbose "AzureRM Modules: Authenticating with Service Principal"
-
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Login-AzureRmAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
-            }
-            elseif ($azModuleInstalled)
-            {
-                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
-                {
-                    Write-Verbose "Enabling AzureRM aliasing"
-
-                    # Turn on AzureRm aliasing
-                    # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
-                    Enable-AzureRmAlias -Scope Process
+                elseif (Get-AzureRmModuleInstalled) {
+                    # AzureRM is not supported on powershell core
+                    Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
+                }                
+            }            
+            else { 
+                # Windows Powershell
+                if (Get-AzureRmModuleInstalled) {
+                    Initialize-AzureRmContext
                 }
-
-                # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
-                Disable-AzContextAutosave -Scope Process
-
-                $AzureEnvironment = Get-AzEnvironment -Name $OctopusAzureEnvironment
-                if (!$AzureEnvironment)
-                {
-                    Write-Error "No Azure environment could be matched given the name $OctopusAzureEnvironment"
-                    exit -2
+                elseif (Get-AzModuleInstalled) {
+                    Initialize-AzContext
                 }
-
-                Write-Verbose "Az Modules: Authenticating with Service Principal"
-
-                # Force any output generated to be verbose in Octopus logs.
-                Write-Host "##octopus[stdout-verbose]"
-                Connect-AzAccount -Credential $creds -TenantId $OctopusAzureADTenantId -SubscriptionId $OctopusAzureSubscriptionId -Environment $AzureEnvironment -ServicePrincipal
-                Write-Host "##octopus[stdout-default]"
             }
             
             If (!$OctopusDisableAzureCLI -or $OctopusDisableAzureCLI -like [Boolean]::FalseString) {

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -70,17 +70,17 @@ Execute-WithRetry{
 
             Get-Alias
 
-            $useAzureRmModule = Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue
+            #$useAzureRmModule = 
             $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5
 
-            if ($useAzureRmModule-and $runningInPowershellCore)
-            {
-                # AzureRM is not supported on powershell core, skip over this authentication method and warn of this
-                Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
-                $useAzureRmModule = $false
-            }            
+            # if ($runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
+            # {
+            #     # AzureRM is not supported on powershell core, skip over this authentication method and warn of this
+            #     Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
+            #     $useAzureRmModule = $false
+            # }            
             
-            if ($useAzureRmModule)
+            if (!$runningInPowershellCore -and (Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue))
             {
                 # Turn off context autosave, as this will make all authentication occur in memory, and isolate each session from the context changes in other sessions
                 Disable-AzureRMContextAutosave -Scope Process
@@ -101,7 +101,7 @@ Execute-WithRetry{
             }
             elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
             {
-                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue) -and !$runningInPowershellCore)
+                if (!$runningInPowershellCore -and -Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
                 {
                     Write-Verbose "Enabling AzureRM aliasing"
 

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -101,6 +101,8 @@ Execute-WithRetry{
             {
                 if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
                 {
+                    Write-Verbose "Enabling AzureRM aliasing"
+
                     # Turn on AzureRm aliasing
                     # See https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-3.0.0#enable-azurerm-compatibility-aliases
                     Enable-AzureRmAlias -Scope Process

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,12 +68,12 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
-            Get-InstalledModule
+            Get-Alias
 
             $useAzureRmModule = Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue
             $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5
 
-            if ($useAzureRmModule -eq $true -and $runningInPowershellCore -eq $true)
+            if ($useAzureRmModule-and $runningInPowershellCore)
             {
                 # AzureRM is not supported on powershell core, skip over this authentication method and warn of this
                 Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"
@@ -101,7 +101,7 @@ Execute-WithRetry{
             }
             elseif (Get-InstalledModule Az -ErrorAction SilentlyContinue)
             {
-                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue))
+                if (-Not(Get-Command "Disable-AzureRMContextAutosave" -errorAction SilentlyContinue) -and !$runningInPowershellCore)
                 {
                     Write-Verbose "Enabling AzureRM aliasing"
 

--- a/source/Calamari/Scripts/AzureContext.ps1
+++ b/source/Calamari/Scripts/AzureContext.ps1
@@ -68,10 +68,12 @@ Execute-WithRetry{
             $securePassword = ConvertTo-SecureString $OctopusAzureADPassword -AsPlainText -Force
             $creds = New-Object System.Management.Automation.PSCredential ($OctopusAzureADClientId, $securePassword)
 
+            Get-InstalledModule
+
             $useAzureRmModule = Get-Command "Login-AzureRmAccount" -ErrorAction SilentlyContinue
             $runningInPowershellCore = $PSVersionTable.PSVersion.Major -gt 5
 
-            if ($useAzureRmModule -And $runningInPowershellCore)
+            if ($useAzureRmModule -eq $true -and $runningInPowershellCore -eq $true)
             {
                 # AzureRM is not supported on powershell core, skip over this authentication method and warn of this
                 Write-Warning "AzureRM module is not compatible with Powershell Core, authentication will not be performed with AzureRM"

--- a/source/Sashimi.Tests/AzurePowerShellActionHandlerFixture.cs
+++ b/source/Sashimi.Tests/AzurePowerShellActionHandlerFixture.cs
@@ -27,8 +27,8 @@ namespace Sashimi.AzureScripting.Tests
 
         [Test]
         [WindowsTest]
-        [RequiresPowerShell5OrAboveAttribute]
-        public void ExecuteAnInlinePowerShellScript()
+        [RequiresPowerShell5OrAbove]
+        public void ExecuteAnInlineWindowsPowerShellScript()
         {
             var psScript = @"
 $ErrorActionPreference = 'Continue'
@@ -45,7 +45,51 @@ az group list";
                                                      context.Variables.Add(KnownVariables.Action.Script.ScriptBody, psScript);
                                                  })
                                     .Execute();
+        }
 
+        [Test]
+        [RequiresPowerShell5OrAbove]
+        public void ExecuteAnInlinePowerShellCoreScript()
+        {
+            var psScript = @"
+$ErrorActionPreference = 'Continue'
+az --version
+Get-AzureEnvironment
+az group list";
+
+            ActionHandlerTestBuilder.CreateAsync<AzurePowerShellActionHandler, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add(Calamari.Common.Plumbing.Variables.PowerShellVariables.Edition, "Core");
+                                                     context.Variables.Add(KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline);
+                                                     context.Variables.Add(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell.ToString());
+                                                     context.Variables.Add(KnownVariables.Action.Script.ScriptBody, psScript);
+                                                 })
+                                    .Execute();
+        }
+
+        [Test]
+        [RequiresPowerShell5OrAbove]
+        public void ExecuteAnInlinePowerShellCoreScriptAgainstAnInvalidAzureEnvironment()
+        {
+            var psScript = @"
+$ErrorActionPreference = 'Continue'
+az --version
+Get-AzureEnvironment
+az group list";
+
+            ActionHandlerTestBuilder.CreateAsync<AzurePowerShellActionHandler, Program>()
+                                    .WithArrange(context =>
+                                                 {
+                                                     AddDefaults(context);
+                                                     context.Variables.Add("Octopus.Action.Azure.Environment", "NotARealAzureEnvironment");
+                                                     context.Variables.Add(Calamari.Common.Plumbing.Variables.PowerShellVariables.Edition, "Core");
+                                                     context.Variables.Add(KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline);
+                                                     context.Variables.Add(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell.ToString());
+                                                     context.Variables.Add(KnownVariables.Action.Script.ScriptBody, psScript);
+                                                 })
+                                    .Execute(false); // Should fail due to invalid azure environment
         }
 
         void AddDefaults(TestActionHandlerContext<Program> context)

--- a/source/Sashimi/AzurePowerShellActionHandler.cs
+++ b/source/Sashimi/AzurePowerShellActionHandler.cs
@@ -15,11 +15,19 @@ namespace Sashimi.AzureScripting
         public bool WhenInAChildStepRunInTheContextOfTheTargetMachine => false;
         public bool CanRunOnDeploymentTarget => false;
         public ActionHandlerCategory[] Categories => new[] { ActionHandlerCategory.BuiltInStep, AzureConstants.AzureActionHandlerCategory, ActionHandlerCategory.Script };
-        public string[] StepBasedVariableNameForAccountIds { get; } = {SpecialVariables.Action.Azure.AccountId};
+        public string[] StepBasedVariableNameForAccountIds { get; } = { SpecialVariables.Action.Azure.AccountId };
 
         public IActionHandlerResult Execute(IActionHandlerContext context, ITaskLog taskLog)
         {
             var syntax = context.Variables.GetEnum(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell);
+
+            var useBundledTooling = context.Variables.GetFlag(KnownVariables.Action.UseBundledTooling, true);
+
+            if (useBundledTooling)
+            {
+                // Warn that the use of bundled tooling is not recommended
+                taskLog.Warn($"Using the Azure tools bundled with Octopus is not recommended. Learn more about Azure Tools: https://g.octopushq.com/AzureTools.");
+            }
 
             var builder = context.CalamariCommand(AzureConstants.CalamariAzure, "run-script")
                                  .WithAzureCLI(context, taskLog);


### PR DESCRIPTION
This PR does the following: 
- Adds a warning to the deployment log if the step is using the bundled tools as this is not recommended
- Initializes the Az context instead of the AzureRM context when running on Powershell Core and adds a warning if AzureRM is present (but Az isn't), so that Azure scripts can run in powershell core if the bundled tools option is selected (or the pre-provisioned worker has AzureRM installed). As part of this some refactoring was done of the way the modules are initialized, I would appreciate some checking here to ensure that haven't broken any existing deployment scenarios.