### PR TITLE
Adds warning to use of bundled tools that are used by other libraries

### DIFF
--- a/source/Sashimi/AzureActionHandlerExtensions.cs
+++ b/source/Sashimi/AzureActionHandlerExtensions.cs
@@ -14,6 +14,13 @@ namespace Sashimi.AzureScripting
             IActionHandlerContext context,
             ITaskLog taskLog)
         {
+            var useBundledTooling = context.Variables.GetFlag(KnownVariables.Action.UseBundledTooling, true);
+
+            if (useBundledTooling)
+            {
+                taskLog.Warn($"Using the Azure tools bundled with Octopus is not recommended. Learn more about Azure Tools: https://g.octopushq.com/AzureTools.");
+            }
+
             return builder.WithAzureCmdlets(context, taskLog).WithAzureCLI(context, taskLog);
         }
 

--- a/source/Sashimi/AzureActionHandlerExtensions.cs
+++ b/source/Sashimi/AzureActionHandlerExtensions.cs
@@ -18,7 +18,7 @@ namespace Sashimi.AzureScripting
 
             if (useBundledTooling)
             {
-                taskLog.Warn($"Using the Azure tools bundled with Octopus is not recommended. Learn more about Azure Tools: https://g.octopushq.com/AzureTools.");
+                taskLog.Warn($"Using the Azure tools bundled with Octopus Deploy is not recommended. Learn more about Azure Tools at https://g.octopushq.com/AzureTools.");
             }
 
             return builder.WithAzureCmdlets(context, taskLog).WithAzureCLI(context, taskLog);

--- a/source/Sashimi/AzurePowerShellActionHandler.cs
+++ b/source/Sashimi/AzurePowerShellActionHandler.cs
@@ -26,7 +26,7 @@ namespace Sashimi.AzureScripting
             if (useBundledTooling)
             {
                 // Warn that the use of bundled tooling is not recommended
-                taskLog.Warn($"Using the Azure tools bundled with Octopus is not recommended. Learn more about Azure Tools: https://g.octopushq.com/AzureTools.");
+                taskLog.Warn($"Using the Azure tools bundled with Octopus Deploy is not recommended. Learn more about Azure Tools at https://g.octopushq.com/AzureTools.");
             }
 
             var builder = context.CalamariCommand(AzureConstants.CalamariAzure, "run-script")


### PR DESCRIPTION
Adds a warning to the method that other libraries use that adds Azure CLI and Powershell module tools, defaulting to including the warning if the property doesn't exist on the step.