### PR TITLE
Update referenced version of Calamari.Scripting

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,7 +15,7 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Scripting" Version="14.0.1" />
+        <PackageReference Include="Calamari.Scripting" Version="14.0.2" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />


### PR DESCRIPTION
This PR does nothing except for updating the version of `Calamari.Scripting` referenced by these projects. This ensures we're transitively referencing the latest version of `Calamari.Common`, which contains proper code signing of referenced binaries and pulls in the proxy fixes from [Calamari PR #754](https://github.com/OctopusDeploy/Calamari/pull/754).