### PR TITLE
Bump Calamari.Scripting in Sashimi.AzureScripting.Calamari from 14.0.2 to 14.1.1

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,7 +15,7 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Scripting" Version="14.0.2" />
+        <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />


### PR DESCRIPTION
Brings through the fix for OctopusDeploy/Issues#7050, which changes the way Bash Script parameters are handled to prevent an unexpected masked variable being set at argument position 1 if no user parameters were provided to the script.