### PR TITLE
Bumps Calamari.* to 18.1.7 and Sashimi.* to 9.0.3 (Server 2021.1 stream)

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,8 +15,8 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="18.1.4" />
-        <PackageReference Include="Calamari.Scripting" Version="9.0.2" />
+        <PackageReference Include="Calamari.Common" Version="18.1.7" />
+        <PackageReference Include="Calamari.Scripting" Version="9.0.3" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="12.1.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
-        <PackageReference Include="Sashimi.Azure.Common" Version="9.0.2" />
-        <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.2" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.2" />
+        <PackageReference Include="Sashimi.Azure.Common" Version="9.0.3" />
+        <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.3" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.3" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream changes:
* OctopusDeploy/Calamari#805
* OctopusDeploy/Sashimi#130

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177