### PR TITLE
Bumps Sashimi.* to 14.0.3 (Server 2021.2 stream)

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,7 +15,7 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Scripting" Version="14.0.1" />
+        <PackageReference Include="Calamari.Scripting" Version="14.0.3" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
-        <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-        <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.1" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+        <PackageReference Include="Sashimi.Azure.Common" Version="14.0.3" />
+        <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.3" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177