### PR TITLE
Bumps Sashimi.* to 14.1.3 (Server 2021.3 Stream)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -95,26 +95,8 @@ Task("Test")
         });
     });
 
-Task("CopyGlobalJsonToTestProjects")
-    .IsDependentOn("Build")
-    .Does(() => {
-        var testProjects = GetFiles("./source/**/*Tests.csproj");
-
-        foreach (var testProject in testProjects)
-        {
-            var frameworks = XmlPeek(testProject, "Project/PropertyGroup/TargetFrameworks") ??
-                XmlPeek(testProject, "Project/PropertyGroup/TargetFramework");
-
-            foreach (var framework in frameworks.Split(';'))
-            {
-                CopyFiles("./global.json", $"{testProject.GetDirectory()}/bin/{configuration}/{framework}");
-            }
-        }
-    });
-
 Task("PublishCalamariProjects")
     .IsDependentOn("Build")
-    .IsDependentOn("CopyGlobalJsonToTestProjects")
     .Does(() => {
         var projects = GetFiles("./source/**/Calamari*.csproj"); //We need Calamari & Calamari.Tests
 		foreach(var project in projects)
@@ -134,6 +116,8 @@ Task("PublishCalamariProjects")
                         Framework = framework,
                         Runtime = runtime
 		    	    });
+
+                    CopyFiles("./global.json", $"{publishDir}/{calamariFlavour}/{platform}");
                 }
 
                 if(framework.Equals("net5.0"))
@@ -154,7 +138,6 @@ Task("PublishCalamariProjects")
 
 Task("PublishSashimiTestProjects")
     .IsDependentOn("Build")
-    .IsDependentOn("CopyGlobalJsonToTestProjects")
     .Does(() => {
         var projects = GetFiles("./source/**/Sashimi.Tests.csproj");
 		foreach(var project in projects)
@@ -167,6 +150,8 @@ Task("PublishSashimiTestProjects")
 		    	    	Configuration = configuration,
                         OutputDirectory = $"{publishDir}/{sashimiFlavour}"
 		    	    });
+
+                    CopyFiles("./global.json", $"{publishDir}/{sashimiFlavour}");
                 }
 
                 RunPublish();

--- a/build.cake
+++ b/build.cake
@@ -118,7 +118,7 @@ Task("PublishCalamariProjects")
 		    	    });
                 }
 
-                if(framework.StartsWith("netcoreapp"))
+                if(framework.Equals("net5.0"))
                 {
                     var runtimes = XmlPeek(project, "Project/PropertyGroup/RuntimeIdentifiers").Split(';');
                     foreach(var runtime in runtimes)

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
     "sdk": {
-      "version": "5.0.100",
-      "rollForward": "latestFeature"
+        "version": "5.0.100",
+        "rollForward": "latestFeature"
     }
-  }
-  
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+      "version": "5.0.100",
+      "rollForward": "latestFeature"
+    }
+  }
+  

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,10 +7,10 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net452;net5.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,19 +9,15 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-        <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net452;net5.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
-        <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     </ItemGroup>
 </Project>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -20,4 +20,8 @@
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />
     </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
+        <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
+    </ItemGroup>
 </Project>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -15,7 +15,7 @@
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
+        <PackageReference Include="Calamari.Scripting" Version="14.1.3" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scripts\*" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
     <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Sashimi.AzureScripting.Tests</RootNamespace>
     <AssemblyName>Sashimi.AzureScripting.Tests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Octopus.Dependencies.AzureCLI" Version="2.0.50" />
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
-        <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-        <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.1" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+        <PackageReference Include="Sashimi.Azure.Common" Version="14.1.3" />
+        <PackageReference Include="Sashimi.Azure.Accounts" Version="14.1.3" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <AssemblyName>Sashimi.AzureScripting</AssemblyName>
         <RootNamespace>Sashimi.AzureScripting</RootNamespace>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
         <PackageProjectUrl>https://github.com/OctopusDeploy/Sashimi.AzureScripting</PackageProjectUrl>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Also includes a compatibility bump to `net5.0` when building the non-netfx targets, cascading from [a corresponding change in `Sashimi` last year](https://github.com/OctopusDeploy/Sashimi/pull/119). This also required addition of a `global.json` and some changes to the Cake script to facilitate correct framework selection on the build agents.

Upstream change:
* OctopusDeploy/Calamari#815
* OctopusDeploy/Sashimi#134

Issues:
* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177