### PR TITLE
[Do not merge] Spike of supporting cloud connections

### DIFF
--- a/source/Calamari/AzureContextScriptWrapper.cs
+++ b/source/Calamari/AzureContextScriptWrapper.cs
@@ -104,11 +104,11 @@ namespace Calamari.AzureScripting
 
         private class AzureCloudConnectionAuthentication
         {
-            public ServicePrincipalAccount Account { get; set; }
+            public ServicePrincipalAccount AccountDetails { get; set; }
 
-            public AzureCloudConnectionAuthentication(ServicePrincipalAccount account)
+            public AzureCloudConnectionAuthentication(ServicePrincipalAccount accountDetails)
             {
-                Account = account;
+                AccountDetails = accountDetails;
             }
         }
 
@@ -153,11 +153,11 @@ namespace Calamari.AzureScripting
             public static AzureContextScriptWrapperAuthentication CreateFromCloudConnectionContext(CloudConnectionContext<AzureCloudConnectionAuthentication> context)
             {
                 return new AzureContextScriptWrapperAuthentication(
-                    context.Authentication.Account.SubscriptionNumber,
-                    context.Authentication.Account.AzureEnvironment ?? DefaultAzureEnvironment,
-                    context.Authentication.Account.ClientId,
-                    context.Authentication.Account.TenantId,
-                    context.Authentication.Account.Password,
+                    context.Authentication.AccountDetails.SubscriptionNumber,
+                    context.Authentication.AccountDetails.AzureEnvironment ?? DefaultAzureEnvironment,
+                    context.Authentication.AccountDetails.ClientId,
+                    context.Authentication.AccountDetails.TenantId,
+                    context.Authentication.AccountDetails.Password,
                     null,
                     null, 
                     null,

--- a/source/Calamari/AzureContextScriptWrapper.cs
+++ b/source/Calamari/AzureContextScriptWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using Calamari.Common.Features.Discovery;
 using Calamari.Common.Features.EmbeddedResources;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Features.Scripting;
@@ -11,6 +12,7 @@ using Calamari.Common.Features.Scripts;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
 
 namespace Calamari.AzureScripting
 {
@@ -49,34 +51,170 @@ namespace Calamari.AzureScripting
             variables.Set("OctopusAzureTargetScript", script.File);
             variables.Set("OctopusAzureTargetScriptParameters", script.Parameters);
 
-            SetOutputVariable("OctopusAzureSubscriptionId", variables.Get(SpecialVariables.Action.Azure.SubscriptionId)!);
-            SetOutputVariable("OctopusAzureStorageAccountName", variables.Get(SpecialVariables.Action.Azure.StorageAccountName)!);
-            var azureEnvironment = variables.Get(SpecialVariables.Action.Azure.Environment, DefaultAzureEnvironment)!;
-            if (azureEnvironment != DefaultAzureEnvironment)
+            var cloudConnectionContext = GetCloudConnectionContext(variables);
+            AzureContextScriptWrapperAuthentication? scriptAuthentication;
+            if (cloudConnectionContext != null)
             {
-                log.InfoFormat("Using Azure Environment override - {0}", azureEnvironment);
+                scriptAuthentication = AzureContextScriptWrapperAuthentication.CreateFromCloudConnectionContext(cloudConnectionContext);
             }
-            SetOutputVariable("OctopusAzureEnvironment", azureEnvironment);
+            else
+            {
+                scriptAuthentication = AzureContextScriptWrapperAuthentication.CreateFromKnownVariables(variables);
+            }
+
+            SetOutputVariable("OctopusAzureSubscriptionId", scriptAuthentication.SubscriptionId);
+            SetOutputVariable("OctopusAzureStorageAccountName", scriptAuthentication.StorageAccountName!);
+            if (scriptAuthentication.AzureEnvironment != DefaultAzureEnvironment)
+            {
+                log.InfoFormat("Using Azure Environment override - {0}", scriptAuthentication.AzureEnvironment!);
+            }
+            SetOutputVariable("OctopusAzureEnvironment", scriptAuthentication.AzureEnvironment!);
             SetOutputVariable("OctopusAzureExtensionsDirectory", variables.Get(SpecialVariables.Action.Azure.ExtensionsDirectory)!);
 
             using (new TemporaryFile(Path.Combine(workingDirectory, "AzureProfile.json")))
             using (var contextScriptFile = new TemporaryFile(CreateContextScriptFile(workingDirectory, scriptSyntax)))
             {
-                if (variables.Get(SpecialVariables.Account.AccountType) == "AzureServicePrincipal")
+                if (scriptAuthentication.UseServicePrincipal)
                 {
                     SetOutputVariable("OctopusUseServicePrincipal", bool.TrueString);
-                    SetOutputVariable("OctopusAzureADTenantId", variables.Get(SpecialVariables.Action.Azure.TenantId)!);
-                    SetOutputVariable("OctopusAzureADClientId", variables.Get(SpecialVariables.Action.Azure.ClientId)!);
-                    variables.Set("OctopusAzureADPassword", variables.Get(SpecialVariables.Action.Azure.Password));
+                    SetOutputVariable("OctopusAzureADTenantId", scriptAuthentication.TenantId!);
+                    SetOutputVariable("OctopusAzureADClientId", scriptAuthentication.ClientId!);
+                    variables.Set("OctopusAzureADPassword", scriptAuthentication.Password);
                     return NextWrapper!.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, commandLineRunner, environmentVars);
                 }
 
                 //otherwise use management certificate
                 SetOutputVariable("OctopusUseServicePrincipal", false.ToString());
-                using (new TemporaryFile(CreateAzureCertificate(workingDirectory)))
+                using (new TemporaryFile(CreateAzureCertificate(workingDirectory, scriptAuthentication)))
                 {
                     return NextWrapper!.ExecuteScript(new Script(contextScriptFile.FilePath), scriptSyntax, commandLineRunner, environmentVars);
                 }
+            }
+        }
+
+        private class CloudConnectionContext<TAuthentication>
+        {
+            public TAuthentication Authentication { get; set; }
+
+            public CloudConnectionContext(TAuthentication authentication)
+            {
+                Authentication = authentication;
+            }
+        }
+
+        private class AzureCloudConnectionAuthentication
+        {
+            public ServicePrincipalAccount Account { get; set; }
+
+            public AzureCloudConnectionAuthentication(ServicePrincipalAccount account)
+            {
+                Account = account;
+            }
+        }
+
+        class AzureContextScriptWrapperAuthentication
+        {
+            public AzureContextScriptWrapperAuthentication(
+                string subscriptionId,
+                string azureEnvironment,
+                string? clientId,
+                string? tenantId,
+                string? password,
+                string? storageAccountName,
+                string? certificateThumbprint,
+                byte[]? certificateBytes,
+                bool useServicePrincipal)
+            {
+                SubscriptionId = subscriptionId;
+                AzureEnvironment = azureEnvironment;
+                ClientId = clientId;
+                TenantId = tenantId;
+                Password = password;
+                StorageAccountName = storageAccountName;
+                CertificateThumbprint = certificateThumbprint;
+                CertificateBytes = certificateBytes;
+                UseServicePrincipal = useServicePrincipal;
+            }
+
+            public static AzureContextScriptWrapperAuthentication CreateFromKnownVariables(IVariables variables)
+            {
+                return new AzureContextScriptWrapperAuthentication(
+                    subscriptionId: variables.Get(SpecialVariables.Action.Azure.SubscriptionId)!,
+                    azureEnvironment: variables.Get(SpecialVariables.Action.Azure.Environment, DefaultAzureEnvironment)!,
+                    clientId: variables.Get(SpecialVariables.Action.Azure.ClientId),
+                    tenantId: variables.Get(SpecialVariables.Action.Azure.TenantId),
+                    password: variables.Get(SpecialVariables.Action.Azure.Password),
+                    variables.Get(SpecialVariables.Action.Azure.StorageAccountName)!,
+                    variables.Get(SpecialVariables.Action.Azure.CertificateThumbprint),
+                    variables.IsSet(SpecialVariables.Action.Azure.CertificateBytes) ? Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes)!) : null,
+                    variables.Get(SpecialVariables.Account.AccountType) == "AzureServicePrincipal");
+            }
+
+            public static AzureContextScriptWrapperAuthentication CreateFromCloudConnectionContext(CloudConnectionContext<AzureCloudConnectionAuthentication> context)
+            {
+                return new AzureContextScriptWrapperAuthentication(
+                    context.Authentication.Account.SubscriptionNumber,
+                    context.Authentication.Account.AzureEnvironment,
+                    context.Authentication.Account.ClientId,
+                    context.Authentication.Account.TenantId,
+                    context.Authentication.Account.Password,
+                    null,
+                    null, 
+                    null,
+                    true);
+            }
+
+            public string SubscriptionId { get; }
+            public string AzureEnvironment { get; }
+            public string? ClientId { get; }
+            public string? TenantId { get; }
+            public string? Password { get; }
+            public string? StorageAccountName { get; set; }
+            public string? CertificateThumbprint { get; set; }
+            public byte[]? CertificateBytes { get; set; }
+            public bool UseServicePrincipal { get; set; }
+        }
+
+        class ServicePrincipalAccount
+        {
+            public ServicePrincipalAccount(
+                string subscriptionNumber,
+                string clientId,
+                string tenantId,
+                string password,
+                string azureEnvironment)
+            {
+                SubscriptionNumber = subscriptionNumber;
+                ClientId = clientId;
+                TenantId = tenantId;
+                Password = password;
+                AzureEnvironment = azureEnvironment;
+            }
+
+            public string SubscriptionNumber { get; }
+            public string ClientId { get; }
+            public string TenantId { get; }
+            public string Password { get; }
+            public string AzureEnvironment { get; }
+        }
+
+        private CloudConnectionContext<AzureCloudConnectionAuthentication>? GetCloudConnectionContext(IVariables variables)
+        {
+            const string contextVariableName = "Octopus.CloudConnection.Context";
+            var json = variables.Get(contextVariableName);
+            if (json == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<CloudConnectionContext<AzureCloudConnectionAuthentication>>(json);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Cloud connection context from variable {contextVariableName} is in wrong format: {ex.Message}");
+                return null;
             }
         }
 
@@ -101,12 +239,12 @@ namespace Calamari.AzureScripting
             return azureContextScriptFile;
         }
 
-        string CreateAzureCertificate(string workingDirectory)
+        string CreateAzureCertificate(string workingDirectory, AzureContextScriptWrapperAuthentication scriptAuthentication)
         {
             var certificateFilePath = Path.Combine(workingDirectory, CertificateFileName);
             var certificatePassword = GenerateCertificatePassword();
-            var azureCertificate = CalamariCertificateStore.GetOrAdd(variables.Get(SpecialVariables.Action.Azure.CertificateThumbprint)!,
-                                                                     Convert.FromBase64String(variables.Get(SpecialVariables.Action.Azure.CertificateBytes)!),
+            var azureCertificate = CalamariCertificateStore.GetOrAdd(scriptAuthentication.CertificateThumbprint!,
+                                                                     scriptAuthentication.CertificateBytes!,
                                                                      StoreName.My);
 
             variables.Set("OctopusAzureCertificateFileName", certificateFilePath);

--- a/source/Calamari/AzureContextScriptWrapper.cs
+++ b/source/Calamari/AzureContextScriptWrapper.cs
@@ -154,7 +154,7 @@ namespace Calamari.AzureScripting
             {
                 return new AzureContextScriptWrapperAuthentication(
                     context.Authentication.Account.SubscriptionNumber,
-                    context.Authentication.Account.AzureEnvironment,
+                    context.Authentication.Account.AzureEnvironment ?? DefaultAzureEnvironment,
                     context.Authentication.Account.ClientId,
                     context.Authentication.Account.TenantId,
                     context.Authentication.Account.Password,
@@ -182,7 +182,7 @@ namespace Calamari.AzureScripting
                 string clientId,
                 string tenantId,
                 string password,
-                string azureEnvironment)
+                string? azureEnvironment)
             {
                 SubscriptionNumber = subscriptionNumber;
                 ClientId = clientId;
@@ -195,7 +195,7 @@ namespace Calamari.AzureScripting
             public string ClientId { get; }
             public string TenantId { get; }
             public string Password { get; }
-            public string AzureEnvironment { get; }
+            public string? AzureEnvironment { get; }
         }
 
         private CloudConnectionContext<AzureCloudConnectionAuthentication>? GetCloudConnectionContext(IVariables variables)

--- a/source/Calamari/AzureContextScriptWrapper.cs
+++ b/source/Calamari/AzureContextScriptWrapper.cs
@@ -154,7 +154,7 @@ namespace Calamari.AzureScripting
             {
                 return new AzureContextScriptWrapperAuthentication(
                     context.Authentication.AccountDetails.SubscriptionNumber,
-                    context.Authentication.AccountDetails.AzureEnvironment ?? DefaultAzureEnvironment,
+                    !string.IsNullOrEmpty(context.Authentication.AccountDetails.AzureEnvironment) ? context.Authentication.AccountDetails.AzureEnvironment! : DefaultAzureEnvironment,
                     context.Authentication.AccountDetails.ClientId,
                     context.Authentication.AccountDetails.TenantId,
                     context.Authentication.AccountDetails.Password,

--- a/source/Sashimi.Tests/AzurePowerShellActionHandlerFixture.cs
+++ b/source/Sashimi.Tests/AzurePowerShellActionHandlerFixture.cs
@@ -71,6 +71,28 @@ az group list";
 
         [Test]
         [RequiresPowerShell5OrAbove]
+        public void ExecuteAnInlinePowerShellCoreScriptWithCloudConnection()
+        {
+            var psScript = @"
+$ErrorActionPreference = 'Continue'
+az --version
+Get-AzureEnvironment
+az group list";
+
+            ActionHandlerTestBuilder.CreateAsync<AzurePowerShellActionHandler, Program>()
+                                    .WithArrange(context =>
+                                    {
+                                        AddCloudConnection(context);
+                                        context.Variables.Add(Calamari.Common.Plumbing.Variables.PowerShellVariables.Edition, "Core");
+                                        context.Variables.Add(KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline);
+                                        context.Variables.Add(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell.ToString());
+                                        context.Variables.Add(KnownVariables.Action.Script.ScriptBody, psScript);
+                                    })
+                                    .Execute();
+        }
+
+        [Test]
+        [RequiresPowerShell5OrAbove]
         public void ExecuteAnInlinePowerShellCoreScriptAgainstAnInvalidAzureEnvironment()
         {
             var psScript = @"
@@ -99,6 +121,20 @@ az group list";
             context.Variables.Add("Octopus.Action.Azure.TenantId", tenantId);
             context.Variables.Add("Octopus.Action.Azure.ClientId", clientId);
             context.Variables.Add("Octopus.Action.Azure.Password", clientSecret);
+        }
+
+        void AddCloudConnection(TestActionHandlerContext<Program> context)
+        {
+            context.Variables.Add("Octopus.CloudConnection.Context", @$"{{
+    ""authentication"": {{
+        ""account"": {{
+            ""subscriptionNumber"": ""{subscriptionId}"",
+            ""tenantId"": ""{tenantId}"",
+            ""clientId"": ""{clientId}"",
+            ""password"": ""{clientSecret}""
+        }}
+    }}    
+}}");
         }
     }
 }

--- a/source/Sashimi/AzurePowerShellActionHandler.cs
+++ b/source/Sashimi/AzurePowerShellActionHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using Octopus.Server.Extensibility.HostServices.Diagnostics;
 using Sashimi.Server.Contracts;
+using Sashimi.Server.Contracts.Accounts;
 using Sashimi.Server.Contracts.ActionHandlers;
 
 namespace Sashimi.AzureScripting
@@ -16,6 +18,7 @@ namespace Sashimi.AzureScripting
         public bool CanRunOnDeploymentTarget => false;
         public ActionHandlerCategory[] Categories => new[] { ActionHandlerCategory.BuiltInStep, AzureConstants.AzureActionHandlerCategory, ActionHandlerCategory.Script };
         public string[] StepBasedVariableNameForAccountIds { get; } = { SpecialVariables.Action.Azure.AccountId };
+        IEnumerable<AccountType> SupportedAccountTypes => new[] { Sashimi.Azure.Accounts.AccountTypes.AzureServicePrincipalAccountType };
 
         public IActionHandlerResult Execute(IActionHandlerContext context, ITaskLog taskLog)
         {

--- a/source/Sashimi/AzurePowerShellActionHandler.cs
+++ b/source/Sashimi/AzurePowerShellActionHandler.cs
@@ -18,7 +18,7 @@ namespace Sashimi.AzureScripting
         public bool CanRunOnDeploymentTarget => false;
         public ActionHandlerCategory[] Categories => new[] { ActionHandlerCategory.BuiltInStep, AzureConstants.AzureActionHandlerCategory, ActionHandlerCategory.Script };
         public string[] StepBasedVariableNameForAccountIds { get; } = { SpecialVariables.Action.Azure.AccountId };
-        IEnumerable<AccountType> SupportedAccountTypes => new[] { Sashimi.Azure.Accounts.AccountTypes.AzureServicePrincipalAccountType };
+        public IEnumerable<AccountType> SupportedAccountTypes => new[] { Sashimi.Azure.Accounts.AccountTypes.AzureServicePrincipalAccountType };
 
         public IActionHandlerResult Execute(IActionHandlerContext context, ITaskLog taskLog)
         {

--- a/source/Sashimi/AzurePowerShellActionHandlerValidator.cs
+++ b/source/Sashimi/AzurePowerShellActionHandlerValidator.cs
@@ -9,12 +9,12 @@ namespace Sashimi.AzureScripting
         public AzurePowerShellActionHandlerValidator()
         {
             // TODO: Don't want this rule to run when cloud connections are configured
-            When(a => a.ActionType == SpecialVariables.Action.Azure.ActionTypeName,
-                 () =>
-                 {
-                     RuleFor(a => a.Properties)
-                         .MustHaveProperty(SpecialVariables.Action.Azure.AccountId, "Please select an Account or provide a variable expression for the Account ID to use.");
-                 });
+            //When(a => a.ActionType == SpecialVariables.Action.Azure.ActionTypeName,
+            //     () =>
+            //     {
+            //         RuleFor(a => a.Properties)
+            //             .MustHaveProperty(SpecialVariables.Action.Azure.AccountId, "Please select an Account or provide a variable expression for the Account ID to use.");
+            //     });
         }
     }
 }

--- a/source/Sashimi/AzurePowerShellActionHandlerValidator.cs
+++ b/source/Sashimi/AzurePowerShellActionHandlerValidator.cs
@@ -8,6 +8,7 @@ namespace Sashimi.AzureScripting
     {
         public AzurePowerShellActionHandlerValidator()
         {
+            // TODO: Don't want this rule to run when cloud connections are configured
             When(a => a.ActionType == SpecialVariables.Action.Azure.ActionTypeName,
                  () =>
                  {

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="Octopus.Dependencies.AzureCmdlets" Version="6.13.1" />
         <PackageReference Include="Sashimi.Azure.Common" Version="14.2.0" />
         <PackageReference Include="Sashimi.Azure.Accounts" Version="14.2.0" />
-        <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.0" />
+        <PackageReference Include="Sashimi.Server.Contracts" Version="14.2.1-geoffl-action-ha0001" />
     </ItemGroup>
     <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
         <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" Importance="high" />


### PR DESCRIPTION
This PR contains a spike on how we might support cloud connections in Sashimi.AzureScripting. It deserializes a known variable `Octopus.CloudConnection.Context` if it exists and uses this to setup the auth as part of the bootstrapper script.